### PR TITLE
Allow using persistent Chrome profile directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## UNRELEASED
+## 1.0.2 (2025-07-08)
 
+- Allow using persistent Chrome profile directory [#53](https://github.com/hlascelles/ferrum-har/pull/53)
 - Auto require Chrome downloader task [#52](https://github.com/hlascelles/ferrum-har/pull/52)
 
 ## 1.0.1 (2025-06-17)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ferrum-har (1.0.1)
+    ferrum-har (1.0.2)
       base64
       ferrum
       selenium_chrome_helper

--- a/README.md
+++ b/README.md
@@ -77,13 +77,23 @@ For further reading, a full list of Chrome switches can be found
 `ferrum-har` uses [semantic versioning](https://semver.org/), so major version changes will usually 
 require additional actions to be taken upgrading from one major version to another. 
 
-## Changelog
+## Persistent Chrome profile
 
-A full changelog can be found here: [CHANGELOG.md](https://github.com/hlascelles/ferrum-har/blob/master/CHANGELOG.md)
+You can specify the ENV `FERRUM_HAR_BROWSER_CONFIG_DIR` to point to a persistent Chrome profile dir
+between runs. This will allow you to do slow setup once, then do fast reruns of your tests. Note
+this should only be used for development purposes, your tests should not rely on a persistent
+profile in CI.
+
+See the [spec/acceptance/test.rb](https://github.com/hlascelles/ferrum-har/blob/master/spec/acceptance/test.rb) for
+an example of how to use this.
 
 ## Single file example
 
-A single file example of how to use `ferrum-har` can be found in the `spec/acceptance/test.rb` file.
+A single file example of how to use `ferrum-har` can be found in [spec/acceptance/test.rb](https://github.com/hlascelles/ferrum-har/blob/master/spec/acceptance/test.rb).
+
+## Changelog
+
+A full changelog can be found here: [CHANGELOG.md](https://github.com/hlascelles/ferrum-har/blob/master/CHANGELOG.md)
 
 ```
 

--- a/lib/ferrum/har/options_extension.rb
+++ b/lib/ferrum/har/options_extension.rb
@@ -9,7 +9,8 @@ module Ferrum
         original_result = super
         # We have to remove the "disable-extensions" option from the default browser extension
         # list because the ferrum-har gem requires an (internal) extension to work.
-        original_result
+        changed =
+          original_result
           .except("disable-extensions")
           # At some point past v134 this stopped extensions loading properly in the first tab.
           .except("no-startup-window")
@@ -17,6 +18,16 @@ module Ferrum
             "auto-open-devtools-for-tabs" => nil, # Chrome devtools must be open to invoke getHAR
             "load-extension" => "#{Ferrum::Har::GEM_DIR}/extension", # Extension that gets the HAR
           )
+
+        # To get a custom config dir to work, we have to remove the "disable-web-security" option
+        if ENV["FERRUM_HAR_BROWSER_CONFIG_DIR"]
+          changed =
+            changed
+            .except("disable-web-security")
+            .merge("user-data-dir" => ENV["FERRUM_HAR_BROWSER_CONFIG_DIR"])
+        end
+
+        changed
       end
     end
   end

--- a/lib/ferrum/har/version.rb
+++ b/lib/ferrum/har/version.rb
@@ -2,6 +2,6 @@
 
 module Ferrum
   module Har
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/spec/acceptance/test.rb
+++ b/spec/acceptance/test.rb
@@ -4,6 +4,11 @@
 local_gem_test = ENV["FERRUM_HAR_TEST_LOCAL_GEM"] == "true"
 ferrum_har_args = local_gem_test ? { path: File.expand_path("../../", __dir__) } : {}
 
+# With this ENV you can persist browser profiles between runs.
+profile_dir = ENV["FERRUM_HAR_BROWSER_CONFIG_DIR"] = "#{__dir__}/.chrome-profile"
+require "fileutils"
+FileUtils.mkdir_p(profile_dir)
+
 # Use an inline gemfile for this script. This takes the place of a normal Gemfile.
 require "bundler/inline"
 gemfile do


### PR DESCRIPTION
This allows a user to specify the ENV `FERRUM_HAR_BROWSER_CONFIG_DIR`, which can point to a persistent Chrome profile dir between runs.